### PR TITLE
Fix for inability to export via FBX

### DIFF
--- a/ds_sp.py
+++ b/ds_sp.py
@@ -285,7 +285,7 @@ class ds_sp_pbr_nodes(bpy.types.Operator):
 
 def ds_sp_fbx_export_sel(self, context):
 
-    _export_name = bpy.context.scene.objects.active.name
+    _export_name = bpy.context.active_object.name
     _export_path = ds_sp_get_export_path()
     _export_file = _export_path + _export_name + '.fbx'
 


### PR DESCRIPTION
On latest 2.8-beta build (tested on Windows), I get an error if I try to export FBX.

Looks like ds_sp_obj_export_sel(...) was updated for 2.8 in commit tagged 1_5_0, but the same change to similar function ds_sp_fbx_export_sel(...) was overlooked.  I didn't look for other issues, but this fix was enough to get exporting to work for me.

Side note:  I'd recommend refactoring out the common parts between the OBJ and FBX code paths into common functions to avoid missing things like that in the future.  (or just have a "exportFileType" parameter that you pass in)